### PR TITLE
add tests to check log content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script:
   - docker exec thredds grep -ir severe logs/ || echo no severe catalina log entries
   - docker exec thredds grep -ir severe content/thredds/logs/ || echo no severe thredds log entries
   - docker exec thredds grep -ir warn content/thredds/logs/ || echo no warn thredds log entries
+  - true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
 
 script:
   - ./.travis/test.sh
-  - docker exec thredds grep -ir severe logs/ || echo no severe catalina log entries
-  - docker exec thredds grep -ir severe content/thredds/logs/ || echo no severe thredds log entries
-  - docker exec thredds grep -ir warn content/thredds/logs/ || echo no warn thredds log entries
-  - docker logs thredds 2>/dev/null | grep -i warn || echo no warn docker log stdout entries
-  - docker logs thredds 2>&1 >/dev/null | grep -i warn || echo no warn docker log stderr entries
+  - docker exec thredds grep -ir severe logs/ && exit 1 || echo no severe catalina log entries
+  - docker exec thredds grep -ir severe content/thredds/logs/ && exit 1 || echo no severe thredds log entries
+  - docker exec thredds grep -ir warn content/thredds/logs/ && exit 1 || echo no warn thredds log entries
+  - docker logs thredds 2>/dev/null | grep -i warn && exit 1 || echo no warn docker log stdout entries
+  - docker logs thredds 2>&1 >/dev/null | grep -i warn && exit 1 || echo no warn docker log stderr entries

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ before_install:
 
 script:
   - ./.travis/test.sh
+  - docker exec thredds ls -la logs/
   - docker exec thredds grep -ir severe logs/ && exit 1 || echo no severe catalina log entries
+  - docker exec thredds ls -la content/thredds/logs/
   - docker exec thredds grep -ir severe content/thredds/logs/ && exit 1 || echo no severe thredds log entries
   - docker exec thredds grep -ir warn content/thredds/logs/ && exit 1 || echo no warn thredds log entries
   - docker logs thredds 2>/dev/null | grep -i warn && exit 1 || echo no warn docker log stdout entries

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ script:
   - docker exec thredds grep -ir severe logs/ || echo no severe catalina log entries
   - docker exec thredds grep -ir severe content/thredds/logs/ || echo no severe thredds log entries
   - docker exec thredds grep -ir warn content/thredds/logs/ || echo no warn thredds log entries
-  - true
+  - docker logs thredds 2>/dev/null | grep -i warn || echo no warn docker log stdout entries
+  - docker logs thredds 2>&1 >/dev/null | grep -i warn || echo no warn docker log stderr entries

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ before_install:
 
 script:
   - ./.travis/test.sh
+  - docker exec thredds grep -ir severe logs/ || echo no severe catalina log entries
+  - docker exec thredds grep -ir severe content/thredds/logs/ || echo no severe thredds log entries
+  - docker exec thredds grep -ir warn content/thredds/logs/ || echo no warn thredds log entries


### PR DESCRIPTION
A clean build should not have any severe log messages.
Warnings may need further filtering as some are expected.